### PR TITLE
Feat/check user order 

### DIFF
--- a/index.js
+++ b/index.js
@@ -474,9 +474,9 @@ async function processorderzksync(chainid, market, zktx) {
         try {
             let [userAccountState, sellSymbol] = await Promise.all([
                 syncProvider.getState(zktx.recipient),
-                syncProvider.tokenSet.resolveTokenSymbol(marketInfo.tokenSell)
+                syncProvider.tokenSet.resolveTokenSymbol(zktx.tokenSell)
             ]);
-            if(zktx.nonce != userAccountState.committed.nonce+1) { throw new Error("User account nonce dose not match.");}
+            if(zktx.nonce != userAccountState.committed.nonce) { throw new Error("User account nonce dose not match.");}
             if(zktx.amount >= userAccountState.committed.balances[sellSymbol]) { throw new Error("User account has not enugh balance.");}
         } catch (e) {
             // pass

--- a/index.js
+++ b/index.js
@@ -477,7 +477,8 @@ async function processorderzksync(chainid, market, zktx) {
                 syncProvider.tokenSet.resolveTokenSymbol(zktx.tokenSell)
             ]);
             if(zktx.nonce != userAccountState.committed.nonce) { throw new Error("User account nonce dose not match.");}
-            if(zktx.amount >= userAccountState.committed.balances[sellSymbol]) { throw new Error("User account has not enugh balance.");}
+            const userBalance = userAccountState.committed.balances[sellSymbol];
+            if(!userBalance || zktx.amount >= userBalance) { throw new Error("User account has not enugh balance.");}
         } catch (e) {
             // pass
         }


### PR DESCRIPTION
After my mm was hit with a numer of failed tx yesterday, I noticed a bad actor could spamm zigzag with wrong tx and would cause mm's to drain their funds with failed tx. Depending on the throughput, this could go quite fast.

The backend should check the nonce and amount for each order, as thouse are not checked by mm's and are fixed (each mm would perform the same check).

Nonce should be equal to committed.nonce
Amount should be less than committed.balances of that token. 

Removed line 487 -> never used. 