### PR TITLE
Fix/nonce checks at the back end

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ import * as starknet from 'starknet';
 import express from 'express';
 import * as Redis from 'redis';
 import Joi from 'joi';
-import * as zksync from "zksync";
 
 dotenv.config()
 
@@ -64,8 +63,6 @@ const zksyncOrderSchema = Joi.object({
 const USER_CONNECTIONS = {}
 const VALID_CHAINS = [1,1000,1001];
 const V1_TOKEN_IDS = {};
-const mainnetSyncProvider = await zksync.getDefaultProvider("mainnet");
-const rinkebySyncProvider = await zksync.getDefaultProvider("rinkeby");
 await populateV1TokenIds();
 
 await updateVolumes();

--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@ async function handleMessage(msg, ws) {
                     const userNonce = update[6];
                     if(userId && userNonce) {
                         if(!NONCES[userId]) { NONCES[userId] = {}; };
-                        // save nonce +1 to protect agains spamming the same nonce
+                        // nonce+1 to save the next expected nonce
                         NONCES[userId][chainid] = userNonce+1;
                     }
                 }

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ const zksyncOrderSchema = Joi.object({
 const USER_CONNECTIONS = {}
 const VALID_CHAINS = [1,1000,1001];
 const V1_TOKEN_IDS = {};
+const NONCES = {};
 await populateV1TokenIds();
 
 await updateVolumes();
@@ -389,6 +390,13 @@ async function handleMessage(msg, ws) {
                     const yesterdayPrice = await redis.get(`dailyprice:${chainid}:${market}:${yesterday}`);
                     const priceChange = (lastprice - yesterdayPrice).toString();
                     broadcastMessage(chainid, null, {op:"lastprice",args: [[[market, lastprice, priceChange]]]});
+                    const userId = update[5];
+                    const userNonce = update[6];
+                    if(userId && userNonce) {
+                        if(!NONCES[userId]) { NONCES[userId] = {}; };
+                        // save nonce +1 to protect agains spamming the same nonce
+                        NONCES[userId][chainid] = userNonce+1;
+                    }
                 }
             }
             break;
@@ -481,6 +489,10 @@ async function processorderzksync(chainid, market, zktx) {
 
     const inputValidation = zksyncOrderSchema.validate(zktx);
     if (inputValidation.error) throw new Error(inputValidation.error);
+
+    if(NONCES[zktx.accountId] && NONCES[zktx.accountId][chainid] && NONCES[zktx.accountId][chainid] > zktx.nonce) {
+        throw new Error("badnonce");
+    }
 
     // Prevent DOS attacks. Rate limit one order every 3 seconds.
     const redis_rate_limit_key = `ratelimit:zksync:${chainid}:${zktx.accountId}`;


### PR DESCRIPTION
Reverted remains of old change for nonce check.

Added nonce check like the one in mm. Only accept order if nonce is at least as high as the last known nonce.

This version allows users to spam the same nonce over and over and only logs filled swaps. At failed swaps (newstatus == 'r') there could be a update of the nonce via the zkSyncProvider. This is not included as i am not sure if this would brick the server.

TODO: If this is merged, mm should send 'userAccountId' and 'nonce' with 'orderstatusupdate'.