### PR TITLE
feat/get live fees and update markets via broadcast marketInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1169,8 +1169,7 @@ async function updateMarketsZkSync(market=null, chainid=1) {
           const ttl = await redis.ttl(redis_key);
           redis.set(redis_key, JSON.stringify(marketInfo));
           redis.expire(redis_key, ttl);
-          console.log(JSON.stringify({op:"marketInfo",args:[marketInfo]}))
-          broadcastMessage(chainid, market_id, {op:"marketInfo",args:[marketInfo]});
+          broadcastMessage(chainid, market_id, {op:"marketinfo",args:[marketInfo]});
         }
     }));
 }


### PR DESCRIPTION
First Part (1090-1116):
- get all active pairs or the selected pair
- get latest marketInfo
- get all aktive tokens


Second Part (1118-1132):
- get all fees in token async


Third Part (1134-1177):
- select base and quote Fee. Calculate second one if only one is defined .../ETH or .../USDC 
- check if base or quote Fee is off by 2.5%
- update redis. Keep TTL to still update 4 times a day.
-  send update via broadcastMessage 