### PR TITLE
Feat/arbitrum support

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -2540,7 +2540,7 @@ export default class API extends EventEmitter {
       } else if (Number.isNaN(amount)) {
         errorMsg.push('Amount is not a number')
       } else if (amount < minSize) {
-        errorMsg.push('Amount to small')
+        errorMsg.push('Amount too small')
       } else if (
         midPrice &&
         (price < midPrice * 0.25 || price > midPrice * 1.75)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+
+export const ARBITRUM_EXCHANGE = '0xaed91038da9121808a95d9de04530c58f0c1a7e8'
+export const ARBITRUM_OPERATOR = 'test'

--- a/src/services/submitorder2.ts
+++ b/src/services/submitorder2.ts
@@ -5,30 +5,27 @@ export const submitorder2: ZZServiceHandler = async (
   ws,
   [chainId, market, zktx]
 ) => {
-  if (chainId === 1 || chainId === 1000) {
-    try {
-      const order = await api.processorderzksync(chainId, market, zktx)
-      if (ws) ws.send(JSON.stringify(order))
-      return order.args
-    } catch (err: any) {
-      console.error(err)
-      const errorMsg = { op: 'error', args: ['submitorder2', err.message] }
-      if (ws) ws.send(JSON.stringify(errorMsg))
-      return errorMsg
+  let msg
+  try {
+    switch (chainId) {
+      case 1: case 1000:
+        msg = await api.processorderzksync(chainId, market, zktx)
+        break
+      case 1001:
+        msg = await api.processorderstarknet(chainId, market, zktx)
+        break
+      case 42161:
+        msg = await api.processOrderZigZag(chainId, market, zktx)
+        break
+      default:
+        msg = { op: 'error', args: ['submitorder3', 'Invalid chainId'] }
     }
-  } else if (chainId === 1001) {
-    try {
-      const order = await api.processorderstarknet(chainId, market, zktx)
-      return order
-    } catch (err: any) {
-      console.error(err)
-      const errorMsg = { op: 'error', args: ['submitorder2', err.message] }
-      if (ws) ws.send(JSON.stringify(errorMsg))
-      return errorMsg
-    }
-  } else {
-    const errorMsg = { op: 'error', args: ['submitorder2', 'Invalid chainId'] }
-    if (ws) ws.send(JSON.stringify(errorMsg))
-    return errorMsg
+  } catch (err: any) {
+    console.error(err)
+    msg = { op: 'error', args: ['submitorder3', err.message] }
   }
+  
+  if (ws) ws.send(JSON.stringify(msg))
+  // submitorder2 only returns the args and should no longer be used
+  return msg.args
 }

--- a/src/services/submitorder3.ts
+++ b/src/services/submitorder3.ts
@@ -8,32 +8,26 @@ export const submitorder3: ZZServiceHandler = async (
   ws,
   [chainId, market, zktx]
 ) => {
-  if (chainId === 1 || chainId === 1000) {
-    try {
-      const order = await api.processorderzksync(chainId, market, zktx)
-      return order
-    } catch (err: any) {
-      console.error(err)
-      const errorMsg = { op: 'error', args: ['submitorder3', err.message] }
-      if (ws) ws.send(JSON.stringify(errorMsg))
-      return errorMsg
+  let msg
+  try {
+    switch (chainId) {
+      case 1: case 1000:
+        msg = await api.processorderzksync(chainId, market, zktx)
+        break
+      case 1001:
+        msg = await api.processorderstarknet(chainId, market, zktx)
+        break
+      case 42161:
+        msg = await api.processOrderZigZag(chainId, market, zktx)
+        break
+      default:
+        msg = { op: 'error', args: ['submitorder3', 'Invalid chainId'] }
     }
-  } else if (chainId === 1001) {
-    try {
-      const errorMsg = { op: 'error', args: ['submitorder2', 'Chain id 1001 not suported for now.'] }
-      if (ws) ws.send(JSON.stringify(errorMsg))
-      return errorMsg
-      const order = await api.processorderstarknet(chainId, market, zktx)
-      return order
-    } catch (err: any) {
-      console.error(err)
-      const errorMsg = { op: 'error', args: ['submitorder3', err.message] }
-      if (ws) ws.send(JSON.stringify(errorMsg))
-      return errorMsg
-    }
-  } else {
-    const errorMsg = { op: 'error', args: ['submitorder3', 'Invalid chainId'] }
-    if (ws) ws.send(JSON.stringify(errorMsg))
-    return errorMsg
+  } catch (err: any) {
+    console.error(err)
+    msg = { op: 'error', args: ['submitorder3', err.message] }
   }
+  
+  if (ws) ws.send(JSON.stringify(msg))
+  return msg
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,21 @@ export type ZZMarketSummary = {
   highestPrice_24h: number,
   lowestPrice_24h: number
 }
+
+
+export type ZigZagOrderSchema = {
+  makerAddress: string,
+  takerAddress: string,
+  feeRecipientAddress: string,
+  senderAddress: string,
+  makerAssetAmount: string,
+  takerAssetAmount: string,
+  makerFee: string,
+  takerFee: string,
+  expirationTimeSeconds: string,
+  salt: string,
+  makerAssetData: string,
+  takerAssetData: string,
+  makerFeeAssetData: string,
+  takerFeeAssetData: string,
+}


### PR DESCRIPTION
> This branch will contain code to create a full limit order exchange on Arbitrum. Arbitrum is a full EVM chain, so most of this code should be re-usable to use on other EVM chains in the future.
> 
> The goal is to have this done in 1-2 months and port the majority of our liquidity from zksync onto Arbitrum.
>  
> New features will include partial fills and support for multiple open orders. A fork of the 0x contracts will be used by the backend for on-chain fill commitments.
https://github.com/ZigZagExchange/frontend/pull/376
