### PR TITLE
Fix/stuck liquidity

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1711,6 +1711,16 @@ export default class API extends EventEmitter {
     return liquidity
   }
 
+  getSnapshotLiquidity = async (
+    chainId: number,
+    market: ZZMarket
+  ) => {
+    const redisKeyLiquidity =`bestliquidity:${chainId}:${market}`
+    const liquidityString = await this.redis.GET(redisKeyLiquidity)
+    const liquidity = liquidityString ? JSON.parse(liquidityString) : []
+    return liquidity
+  }
+
   getopenorders = async (chainId: number, market: string) => {
     chainId = Number(chainId)
     const query = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -2216,7 +2216,7 @@ export default class API extends EventEmitter {
 
         // Set new liquidity
         redisMembers.push({
-          score: l[1],
+          score: formatPrice(price),
           value: JSON.stringify(l),
         })
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -2106,7 +2106,7 @@ export default class API extends EventEmitter {
       const markets = await this.redis.SMEMBERS(`activemarkets:${chainId}`)
       if (!markets || markets.length === 0) return
       const results: Promise<any>[] = markets.map(async (marketId) => {
-        const liquidity = await this.redis.GET(`bestliquidity:${chainId}:${marketId}`);
+        const liquidity = await this.redis.GET(`bestliquidity:${chainId}:${marketId}`)
         if (liquidity) {
             this.broadcastMessage(
               chainId,
@@ -2201,7 +2201,7 @@ export default class API extends EventEmitter {
       } else if (Number.isNaN(amount)) {
         errorMsg.push('Amount is not a number')
       } else if (amount < minSize) {
-        errorMsg.push('Amount to small')
+        // errorMsg.push('Amount to small')
       } else if (
         midPrice &&
         (price < midPrice * 0.25 || price > midPrice * 1.75)

--- a/src/background.ts
+++ b/src/background.ts
@@ -549,8 +549,8 @@ async function removeOldLiquidity() {
       )
 
       // Store 100 best bids and asks per market
-      const bestLiquidity = [...asks, ...bids];
-      redis.SET(`bestliquidity:${chainId}:${marketId}`, JSON.stringify(bestLiquidity));
+      const bestLiquidity = asks.concat(bids)
+      redis.SET(`bestliquidity:${chainId}:${marketId}`, JSON.stringify(bestLiquidity))
     })
     await Promise.all(results1)
   })

--- a/src/background.ts
+++ b/src/background.ts
@@ -550,7 +550,11 @@ async function removeOldLiquidity() {
 
       // Store 100 best bids and asks per market
       const bestLiquidity = asks.concat(bids)
-      redis.SET(`bestliquidity:${chainId}:${marketId}`, JSON.stringify(bestLiquidity))
+      redis.SET(
+        `bestliquidity:${chainId}:${marketId}`,
+        JSON.stringify(bestLiquidity),
+        { EX: oldLiquidityTime * 2 }        
+      )
     })
     await Promise.all(results1)
   })

--- a/src/background.ts
+++ b/src/background.ts
@@ -502,8 +502,8 @@ async function removeOldLiquidity() {
 
       // Update last price 
       // Only use 100 best bids and asks
-      const asks = marketLiquidity.filter((l) => l[0] === 's').slice(0,100);
-      const bids = marketLiquidity.filter((l) => l[0] === 'b').slice(-100);
+      const asks = marketLiquidity.filter((l) => l[0] === 's').slice(0,100)
+      const bids = marketLiquidity.filter((l) => l[0] === 'b').slice(-100)
       if (asks.length === 0 || bids.length === 0) return
       let askPrice = 0
       let askVolume = 0
@@ -535,15 +535,15 @@ async function removeOldLiquidity() {
 }
 
 async function runDbMigration() {
-    console.log("running db migration");
+    console.log("running db migration")
     const migration = fs.readFileSync(path.join(__dirname, '../schema.sql'), 'utf8')
     db.query(migration).catch(console.error)
 }
 
 async function start() {
-  await redis.connect();
-  await publisher.connect();
-  //await runDbMigration();
+  await redis.connect()
+  await publisher.connect()
+  //await runDbMigration()
 
   console.log("background.ts: Starting Update Functions")
   ZKSYNC_BASE_URL.mainnet = "https://api.zksync.io/api/v0.2/"


### PR DESCRIPTION
[format price in redis](https://github.com/ZigZagExchange/backend/commit/0d49c8548e42b1ff28c8d14f546bcb591cd02757)
These number will be cut in the UI anyway, helps with grouping orders later

[add bestliquidity expiery](https://github.com/ZigZagExchange/backend/commit/402f39e364a259eb456ac77ad3f7ab21455e1993)
This is needed, as otherwiese it will display the last set liquidity forever