### PR TITLE
fix cancel order bug

### DIFF
--- a/evm_contracts/contracts/LibOrder.sol
+++ b/evm_contracts/contracts/LibOrder.sol
@@ -20,7 +20,7 @@ library LibOrder {
   }
 
   // https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct
-  function getOrderHash(Order memory order) internal pure returns (bytes32 orderHash) {
+  function getContentHash(Order memory order) internal pure returns (bytes32 orderHash) {
     orderHash = keccak256(
       abi.encode(_EIP712_ORDER_SCHEMA_HASH, order.user, order.sellToken, order.buyToken, order.sellAmount, order.buyAmount, order.expirationTimeSeconds)
     );

--- a/evm_contracts/test/FillOrderBook.ts
+++ b/evm_contracts/test/FillOrderBook.ts
@@ -594,7 +594,7 @@ describe('FillOrderBook', () => {
     const signedLeftMessageA = await signOrder(TESTRPC_PRIVATE_KEYS_STRINGS[0], makerOrderA, exchangeContract.address)
     const signedLeftMessageB = await signOrder(TESTRPC_PRIVATE_KEYS_STRINGS[2], makerOrderB, exchangeContract.address)
 
-    const orderHashA = await getOrderHash(makerOrderA)
+    const orderHashA = await getOrderHash(makerOrderA, exchangeContract.address)
     const fillAmount = ethers.utils.parseEther('100')
 
     expect(
@@ -635,8 +635,8 @@ describe('FillOrderBook', () => {
     const signedLeftMessageA = await signOrder(TESTRPC_PRIVATE_KEYS_STRINGS[0], makerOrderA, exchangeContract.address)
     const signedLeftMessageB = await signOrder(TESTRPC_PRIVATE_KEYS_STRINGS[2], makerOrderB, exchangeContract.address)
 
-    const orderHashA = await getOrderHash(makerOrderA)
-    const orderHashB = await getOrderHash(makerOrderB)
+    const orderHashA = await getOrderHash(makerOrderA, exchangeContract.address)
+    const orderHashB = await getOrderHash(makerOrderB, exchangeContract.address)
     const fillAmount = ethers.utils.parseEther('200')
 
     expect(

--- a/evm_contracts/test/FillOrderExactInput.ts
+++ b/evm_contracts/test/FillOrderExactInput.ts
@@ -460,7 +460,7 @@ describe('fillOrderExactInput', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -510,7 +510,7 @@ describe('fillOrderExactInput', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 

--- a/evm_contracts/test/FillOrderExactInputETH.ts
+++ b/evm_contracts/test/FillOrderExactInputETH.ts
@@ -425,7 +425,7 @@ describe('fillOrderExactInputETH_Deposit', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -476,7 +476,7 @@ describe('fillOrderExactInputETH_Deposit', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 
@@ -1050,7 +1050,7 @@ describe('fillOrderExactInputETH_Withdraw', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -1100,7 +1100,7 @@ describe('fillOrderExactInputETH_Withdraw', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 

--- a/evm_contracts/test/FillOrderExactOutput.ts
+++ b/evm_contracts/test/FillOrderExactOutput.ts
@@ -478,7 +478,7 @@ describe('fillOrderExactOutput', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -528,7 +528,7 @@ describe('fillOrderExactOutput', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 

--- a/evm_contracts/test/FillOrderExactOutputETH.ts
+++ b/evm_contracts/test/FillOrderExactOutputETH.ts
@@ -444,7 +444,7 @@ describe('fillOrderExactOutputETH_Deposit', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -495,7 +495,7 @@ describe('fillOrderExactOutputETH_Deposit', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 
@@ -1018,7 +1018,7 @@ describe('fillOrderExactOutputETH_Withdraw', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('50')
 
@@ -1057,7 +1057,7 @@ describe('fillOrderExactOutputETH_Withdraw', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
 

--- a/evm_contracts/test/FillOrderRoute.ts
+++ b/evm_contracts/test/FillOrderRoute.ts
@@ -82,7 +82,7 @@ describe('fillOrderRoute', () => {
       exchangeContract.address
     )
 
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     await expect(
@@ -169,8 +169,8 @@ describe('fillOrderRoute', () => {
       makerOrderTwo,
       exchangeContract.address
     )
-    const orderHashOne = await getOrderHash(makerOrderOne)
-    const orderHashTwo = await getOrderHash(makerOrderTwo)
+    const orderHashOne = await getOrderHash(makerOrderOne, exchangeContract.address)
+    const orderHashTwo = await getOrderHash(makerOrderTwo, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     await expect(
@@ -318,9 +318,9 @@ describe('fillOrderRoute', () => {
       exchangeContract.address
     )
 
-    const orderHashOne = await getOrderHash(makerOrderOne)
-    const orderHashTwo = await getOrderHash(makerOrderTwo)
-    const orderHashThree = await getOrderHash(makerOrderThree)
+    const orderHashOne = await getOrderHash(makerOrderOne, exchangeContract.address)
+    const orderHashTwo = await getOrderHash(makerOrderTwo, exchangeContract.address)
+    const orderHashThree = await getOrderHash(makerOrderThree, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     await expect(
@@ -537,10 +537,10 @@ describe('fillOrderRoute', () => {
       exchangeContract.address
     )
 
-    const orderHashOne = await getOrderHash(makerOrderOne)
-    const orderHashTwo = await getOrderHash(makerOrderTwo)
-    const orderHashThree = await getOrderHash(makerOrderThree)
-    const orderHashFour = await getOrderHash(makerOrderFour)
+    const orderHashOne = await getOrderHash(makerOrderOne, exchangeContract.address)
+    const orderHashTwo = await getOrderHash(makerOrderTwo, exchangeContract.address)
+    const orderHashThree = await getOrderHash(makerOrderThree, exchangeContract.address)
+    const orderHashFour = await getOrderHash(makerOrderFour, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     await expect(

--- a/evm_contracts/test/FillOrderRouteETH.ts
+++ b/evm_contracts/test/FillOrderRouteETH.ts
@@ -162,7 +162,7 @@ describe('fillOrderRouteETH_Deposit', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const balance3Before = await provider.getBalance(wallets[0].address)
     const fillAmount = ethers.utils.parseEther('100')
@@ -268,8 +268,8 @@ describe('fillOrderRouteETH_Deposit', () => {
       makerOrderTwo,
       exchangeContract.address
     )
-    const orderHashOne = await getOrderHash(makerOrderOne)
-    const orderHashTwo = await getOrderHash(makerOrderTwo)
+    const orderHashOne = await getOrderHash(makerOrderOne, exchangeContract.address)
+    const orderHashTwo = await getOrderHash(makerOrderTwo, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     const balance1_2Before = await provider.getBalance(wallets[0].address)
@@ -477,7 +477,7 @@ describe('fillOrderRouteETH_Withdraw', () => {
       makerOrder,
       exchangeContract.address
     )
-    const orderHash = await getOrderHash(makerOrder)
+    const orderHash = await getOrderHash(makerOrder, exchangeContract.address)
 
     const balance2Before = await provider.getBalance(wallets[0].address)
     const fillAmount = ethers.utils.parseEther('100')
@@ -587,8 +587,8 @@ describe('fillOrderRouteETH_Withdraw', () => {
       makerOrderTwo,
       exchangeContract.address
     )
-    const orderHashOne = await getOrderHash(makerOrderOne)
-    const orderHashTwo = await getOrderHash(makerOrderTwo)
+    const orderHashOne = await getOrderHash(makerOrderOne, exchangeContract.address)
+    const orderHashTwo = await getOrderHash(makerOrderTwo, exchangeContract.address)
 
     const fillAmount = ethers.utils.parseEther('100')
     const balance7_2Before = await provider.getBalance(wallets[0].address)

--- a/evm_contracts/test/Signature.ts
+++ b/evm_contracts/test/Signature.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat'
 import { expect } from 'chai'
 import { Contract, Wallet } from 'ethers'
 import { TESTRPC_PRIVATE_KEYS_STRINGS } from './utils/PrivateKeyList'
-import { signOrder, signCancelOrder, getOrderHash } from './utils/SignUtil'
+import { signOrder, getOrderHash } from './utils/SignUtil'
 import { Order } from './utils/types'
 
 describe('Signature Validation', () => {
@@ -66,7 +66,7 @@ describe('Signature Validation', () => {
   })
 
   it("Should emit event cancel order", async () => {
-    const orderHash = await getOrderHash(order)
+    const orderHash = await getOrderHash(order, exchangeContract.address)
 
     expect(await exchangeContract.connect(wallet).cancelOrder(
       Object.values(order)

--- a/evm_contracts/test/utils/SignUtil.ts
+++ b/evm_contracts/test/utils/SignUtil.ts
@@ -2,28 +2,33 @@
 import { ethers } from 'ethers'
 import { Order } from './types'
 
-export async function getOrderHash(order: Order) {
-  const types = {
-    Order: [
-      { name: 'user', type: 'address' },
-      { name: 'sellToken', type: 'address' },
-      { name: 'buyToken', type: 'address' },
-      { name: 'sellAmount', type: 'uint256' },
-      { name: 'buyAmount', type: 'uint256' },
-      { name: 'expirationTimeSeconds', type: 'uint256' },
-    ]
-  }
-  const orderMessage = {
-    user: order.user,
-    sellToken: order.sellToken,
-    buyToken: order.buyToken,
-    sellAmount: order.sellAmount,
-    buyAmount: order.buyAmount,
-    expirationTimeSeconds: order.expirationTimeSeconds,
-  }
-
-  // eslint-disable-next-line no-underscore-dangle
-  return ethers.utils._TypedDataEncoder.from({ Order: types.Order }).hash(orderMessage)
+export async function getOrderHash(order: Order, exchangeAddress: string) {
+  return ethers.utils._TypedDataEncoder.hash(
+    {
+      name: 'ZigZag',
+      version: '2.1',
+      chainId: '31337', // test hardhat default
+      verifyingContract: exchangeAddress,
+    },
+    {
+      Order: [
+        { name: 'user', type: 'address' },
+        { name: 'sellToken', type: 'address' },
+        { name: 'buyToken', type: 'address' },
+        { name: 'sellAmount', type: 'uint256' },
+        { name: 'buyAmount', type: 'uint256' },
+        { name: 'expirationTimeSeconds', type: 'uint256' },
+      ]
+    },
+    {
+      user: order.user,
+      sellToken: order.sellToken,
+      buyToken: order.buyToken,
+      sellAmount: order.sellAmount,
+      buyAmount: order.buyAmount,
+      expirationTimeSeconds: order.expirationTimeSeconds,
+    }
+  )
 }
 
 export async function signOrder(


### PR DESCRIPTION
- change LibOrder -> getOrderHash is only the content hash
- add getOrderHash -> use LibOrder to hash content, then OZ _hashTypedDataV4 to get eip712 hash
- update tests to use eip712 hash, not only context hash